### PR TITLE
Bump dependency versions

### DIFF
--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,13 +1,13 @@
 [versions]
-androidx-activity = "1.12.4"
+androidx-activity = "1.13.0"
 androidx-compose = "1.10.5"
-androidx-lifecycle = "2.10.0"
-androidx-navigation = "2.9.7"
-coil = "3.4.0"
+androidx-lifecycle = "2.11.0-beta01"
+androidx-navigation = "2.9.8"
+coil = "3.5.0"
 compose-material-icons = "1.7.3"
 kmp-observable-viewmodel = "1.0.2"
-koin = "4.1.1"
-ktor = "3.4.1"
+koin = "4.2.2"
+ktor = "3.5.1"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }


### PR DESCRIPTION
Bumps the shared dependency versions across the sample.

Only versions the sample already declares are touched. Kotlin, Gradle, AGP and
Compose come from the Kotlin Toolchain CLI rather than the catalog, so they are
not part of this change.
